### PR TITLE
Refactor MCP server configuration keys for consistency

### DIFF
--- a/docs/hands-on/mcp-server-starter.md
+++ b/docs/hands-on/mcp-server-starter.md
@@ -1271,7 +1271,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "Windows"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "uv",
               "args": [
@@ -1288,7 +1288,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "macOS/Linux"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "uv",
               "args": [
@@ -1307,7 +1307,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "Windows"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "node",
               "args": ["C:\\ABSOLUTE\\PATH\\TO\\PARENT\\FOLDER\\weather-mcp\\build\\index.js"]
@@ -1319,7 +1319,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "macOS/Linux"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "node",
               "args": ["/ABSOLUTE/PATH/TO/PARENT/FOLDER/weather-mcp/build/index.js"]
@@ -1333,7 +1333,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "Windows"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "java",
               "args": [
@@ -1348,7 +1348,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "macOS/Linux"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "java",
               "args": [
@@ -1365,7 +1365,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "Windows"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "java",
               "args": [
@@ -1380,7 +1380,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "macOS/Linux"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "java",
               "args": [
@@ -1397,7 +1397,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "Windows"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "dotnet",
               "args": [
@@ -1414,7 +1414,7 @@ For adding an MCP server in your workspace, create a `.vscode/mcp.json` file in 
     === "macOS/Linux"
         ```json
         {
-          "mcpServers": {
+          "servers": {
             "weather": {
               "command": "dotnet",
               "args": [


### PR DESCRIPTION
This pull request updates the documentation for configuring an MCP server by renaming the `mcpServers` key in the `.vscode/mcp.json` file to `servers`. This change ensures consistency across all examples provided in the documentation.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```